### PR TITLE
Create tag pipeline

### DIFF
--- a/etlw.py
+++ b/etlw.py
@@ -15,6 +15,7 @@ from losttheplotly import run_plotline
 from cellularautomaton import *
 from karmametric import run_metric_pipeline
 from flipthetable import run_pg_pandas_transfer
+from nobacksies import run_tag_pipeline
 from utils import timed, print_and_log, get_config_field, get_valid_users, get_valid_posts, \
     get_valid_comments, get_valid_votes, get_valid_views
 
@@ -723,7 +724,7 @@ def enrich_collections(colls_dfs, date_str):  # dict[str:df] -> dict[str:df]
 
 @timed
 def run_etlw_pipeline(date_str, from_file=False, clean_up=True, plotly=True, gsheets=True,
-                      metrics=True, postgres=True, limit=None):
+                      metrics=True, postgres=True, tags=True, limit=None):
     # ##1. LOAD DATA
     if from_file:
         dfs_enriched = load_from_file(date_str)
@@ -752,7 +753,11 @@ def run_etlw_pipeline(date_str, from_file=False, clean_up=True, plotly=True, gsh
     if postgres:
         run_pg_pandas_transfer(dfs_enriched, date_str=date_str)
 
-    # ##8. CLEAN UP OLD FILES TO SAVE SPACE
+    # ##8. RUN TAGS PIPELINE
+    if tags:
+        run_tag_pipeline(dfs_enriched)
+
+    # ##9. CLEAN UP OLD FILES TO SAVE SPACE
     if clean_up:
         clean_up_old_files(days_to_keep=2)
 
@@ -766,5 +771,6 @@ if __name__ == '__main__':
                       gsheets=True,
                       metrics=True,
                       postgres=True,
+                      tags = True,
                       clean_up=True
                       )

--- a/etlw.py
+++ b/etlw.py
@@ -17,38 +17,13 @@ from karmametric import run_metric_pipeline
 from flipthetable import run_pg_pandas_transfer
 from nobacksies import run_tag_pipeline
 from utils import timed, print_and_log, get_config_field, get_valid_users, get_valid_posts, \
-    get_valid_comments, get_valid_votes, get_valid_views
+    get_valid_comments, get_valid_votes, get_valid_views, get_collection, get_mongo_db_object
 
 MONGO_DB_NAME = get_config_field('MONGODB', 'db_name')
 MONGO_DB_URL = get_config_field('MONGODB', 'prod_db_url')
 BASE_PATH = get_config_field('PATHS','base')
 ENV = get_config_field('ENV', 'env')
 
-
-def get_mongo_db_object():
-    client = MongoClient(MONGO_DB_URL)
-    db = client[MONGO_DB_NAME]
-    return db
-
-
-def get_collection(coll_name, db, projection=None, query_filter=None, limit=None):
-    """
-    Downloads and returns single collection from MongoDB and returns dataframe.
-
-    Optional query filter can be applied (useful for downloading logins post-views from events table.
-    Returns a dataframe.
-    """
-
-    kwargs = {} # necessary because pymongo function doesn't accept limit=None
-    if limit:
-        kwargs.update({'limit':limit})
-
-    print_and_log('{} download started at {}. . .'.format(coll_name, datetime.datetime.today()))
-    coll_list = db[coll_name].find(query_filter, projection=projection, **kwargs)
-    coll_df = pd.DataFrame(list(coll_list))
-    print_and_log('{} download completed at {}!'.format(coll_name, datetime.datetime.today()))
-
-    return coll_df
 
 
 @timed

--- a/flipthetable.py
+++ b/flipthetable.py
@@ -239,6 +239,7 @@ def create_tables(tables, conn=None):
 @timed
 def bulk_upload_to_pg(df, table_name, conn=None):
 
+    df = df.copy()
     df.loc[:,'birth'] = pd.datetime.now()
     df.columns = df.columns.to_series().apply(camel_to_snake)
     df = clean_text(df)

--- a/karmametric.py
+++ b/karmametric.py
@@ -18,9 +18,11 @@ def filtered_and_enriched_votes(dfs):
     excluded_posts = dfp[(dfp['status'] != 2) | dfp['authorIsUnreviewed'] | dfp['draft']]['_id']
     lw_team = dfu[dfu['username'].isin(['Benito', 'habryka4', 'Raemon', 'jimrandomh', 'Ruby'])]['_id']
 
-    dfvv = dfv[(~dfv['userId'].isin(lw_team)) & (~dfv['documentId'].isin(excluded_posts)) & (
-        ~dfv['cancelled']) & (
-                   ~dfv['documentId'].isin(dfc[dfc['deleted']]['_id']))].copy()  # dfvv: filtered votes column
+    dfvv = dfv[(~dfv['userId'].isin(lw_team)) & (~dfv['documentId'].isin(excluded_posts))
+                & (dfv['collectionName'].isin(['Posts', 'Comments'])
+                & ~dfv['cancelled'])
+                & (~dfv['documentId'].isin(dfc[dfc['deleted']]['_id']))
+    ].copy()  # dfvv: filtered votes column
     dfvv['downvote'] = dfvv['power'] < 0  # create boolean column for later convenience
 
     dfvv.loc[:, 'power_d4'] = dfvv['power'].copy()  # create a copy of the power (karma) column

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -1,5 +1,7 @@
-from utils import htmlBody2plaintext
+import pandas as pd
 import etlw as et
+from utils import htmlBody2plaintext
+from cellularautomaton import upload_to_gsheets
 
 
 
@@ -77,24 +79,177 @@ def format_tags_table_for_upload(tags_table):
     return output
 
 
+def get_lw_team(dfu):
+    return (dfu[dfu['username']
+            .isin(['Benito', 'habryka4', 'Raemon', 'jimrandomh', 'Ruby'])]
+            .set_index('_id')['displayName']
+            .to_frame('team_member_name')
+            )
 
 
+def enrich_tag_votes(votes, users):
+    lw_team = get_lw_team(users)
 
-def run_tag_pipeline(dfs):
+    latest_vote = (votes
+                   .groupby('documentId')['votedAt']
+                   .max()
+                   .to_frame('latest_vote_on_tag')
+                   )
+
+    votes_enriched = (votes
+                      .merge(latest_vote, on='documentId')
+                      .merge(lw_team, left_on='userId', right_index=True, how='left')
+                      )
+
+    votes_enriched['is_latest_vote'] = votes_enriched['latest_vote_on_tag'] == votes_enriched['votedAt']
+    votes_enriched['voter_identity'] = votes_enriched['team_member_name'].fillna(
+        'user: ' + votes_enriched['userId'].str.slice(6, 9))
+
+    return votes_enriched
+
+
+def get_team_vote_stats(votes_enriched):
+    votes_enriched['voteType'] = votes_enriched['voteType'].astype(str)
+    team_downvotes = (votes_enriched[votes_enriched['power'] < 1]
+                      .groupby('documentId')
+                      .size()
+                      .to_frame('num_team_downvotes')
+                      )
+
+    team_votes = (votes_enriched[votes_enriched['team_member_name'].notnull()]
+                  .groupby(['documentId', 'team_member_name'])['voteType']
+                  .first()
+                  .unstack('team_member_name')
+                  .merge(team_downvotes, left_index=True, right_index=True, how='left')
+                  )
+
+    team_votes['num_team_downvotes'] = team_votes['num_team_downvotes'].fillna(0)
+
+    return team_votes[['Ben Pace', 'habryka', 'jimrandomh', 'Raemon', 'Ruby', 'num_team_downvotes']]
+
+
+def get_tags_on_post(tag_rels, tags):
+    posts_with_tags = (tag_rels
+                       .merge(tags[['_id', 'name']], left_on='tagId', right_on='_id')
+                       .groupby('postId')['name']
+                       .apply(lambda x: ';  '.join(x))
+                       .to_frame('tags_on_post')
+                       )
+
+    return posts_with_tags
+
+
+def enrich_tag_rels(tag_rels, tags, posts):
+    def get_post_tag_ranks(tag_rels, posts):
+        tag_positions = tag_rels.merge(posts[['_id', 'baseScore']], left_on='postId', right_on='_id',
+                                       suffixes=['', '_post'], how='inner')
+        tag_positions['tag_score_rank'] = tag_positions.groupby('tagId')['score'].rank(ascending=False, method='min')
+        tag_positions['tie_break_rank'] = tag_positions.groupby(['tagId', 'tag_score_rank'])['baseScore_post'].rank(
+            ascending=False, method='min')
+        tag_positions['relevance_rank'] = tag_positions['tag_score_rank'] + tag_positions['tie_break_rank'] - 1
+
+        return tag_positions[['_id', 'tagId', 'postId', 'relevance_rank']]
+
+    tag_positions = get_post_tag_ranks(tag_rels, posts)
+    tags_on_posts = get_tags_on_post(tag_rels, tags)
+
+    tag_rels_enriched = (tag_rels
+                         .drop(['baseScore'], axis=1)
+                         .merge(posts[['_id', 'displayName', 'baseScore', 'title', 'postedAt']], left_on='postId',
+                                right_on='_id', suffixes=['', '_post'], how='left')
+                         .rename(
+        {'_id': 'documentId', 'displayName': 'post_author', 'title': 'post_title', 'baseScore': 'post_karma',
+         'postedAt': 'posted_at_post', 'score': 'relevance_score'}, axis=1)
+                         .merge(tags[['_id', 'slug', 'name', 'core', 'postCount']], left_on='tagId', right_on='_id',
+                                how='left', suffixes=['', '_tag'])
+                         .rename(
+        {'name': 'tag_name', 'core': 'is_core_tag', 'postCount': 'post_count', 'deleted': 'tag_deleted'}, axis=1)
+                         .merge(tag_positions[['_id', 'relevance_rank']].set_index('_id'), left_on='documentId',
+                                right_index=True, how='left')
+                         .merge(tags_on_posts, left_on='postId', right_index=True, how='left')
+                         )
+
+    tag_rels_enriched['is_core_tag'] = tag_rels_enriched['is_core_tag'].fillna(False)
+
+    return tag_rels_enriched
+
+
+def get_mega_tag_votes_table(tags, tag_rels, tag_votes, posts, users):
+    tag_votes_enriched = enrich_tag_votes(tag_votes, users)
+    tag_rels_enriched = enrich_tag_rels(tag_rels, tags, posts)
+    team_vote_stats = get_team_vote_stats(tag_votes_enriched)
+
+    mega_tab_votes_table = (tag_rels_enriched
+                            .merge(tag_votes_enriched, on='documentId', how='right', indicator=True)
+                            .merge(team_vote_stats, on='documentId', how='left')
+                            )
+
+    return mega_tab_votes_table
+
+
+def format_mega_votes_table(table):
+    table = table.copy()
+    table['tag_name'] = '=HYPERLINK("www.lesswrong.com/tag/'.lower() + table['slug'] + '", "' + table['tag_name'] + '")'
+    table['post_title'] = '=HYPERLINK("www.lesswrong.com/posts/' + table['postId'] + '", "' + table[
+        'post_title'].str.replace('"', '""') + '")'
+
+    cols = [
+        'post_author',
+        'post_karma',
+        'posted_at_post',
+        'post_title',
+        'is_core_tag',
+        'tag_name',
+        'votedAt',
+        'latest_vote_on_tag',
+        'is_latest_vote',
+        'voter_identity',
+        'voteType',
+        'relevance_rank',
+        'relevance_score',
+        'voteCount',
+        'Ben Pace',
+        'habryka',
+        'jimrandomh',
+        'Raemon',
+        'Ruby',
+        'post_count',
+        'tags_on_post',
+        'tag_deleted',
+        'num_team_downvotes'
+    ]
+
+    return table[cols].sort_values(['votedAt'], ascending=[False])
+
+
+def run_tag_pipeline(dfs, upload=True):
+    votes = dfs['votes']
+    posts = dfs['posts']
+    users = dfs['users']
+
     mongo_db = et.get_mongo_db_object()
 
     tags = et.get_collection('tags', mongo_db)
     tag_rels = et.get_collection('tagrels', mongo_db)
 
-    votes = dfs['votes']
-    tag_votes = votes[votes['collectionName']=='TagRels']
-    posts = dfs['posts']
+    tag_votes = votes[votes['collectionName'] == 'TagRels']
+
+    tags_table = create_tags_table(tag_votes, tags.copy(), tag_rels, posts, mongo_db)
+    tags_table_formatted = format_tags_table_for_upload(tags_table)
+    tags_table_formatted['birth'] = pd.datetime.now()
+    _ = upload_to_gsheets(tags_table_formatted,
+                          'Tag Activity Dashboard', 'Tags',
+                          format_columns=True)
+
+    mega_tag_votes_table = get_mega_tag_votes_table(tags, tag_rels, tag_votes, posts, users)
+    mega_tag_votes_table_formatted = format_mega_votes_table(mega_tag_votes_table)
+    mega_tag_votes_table_formatted['birth'] = pd.datetime.now()
+    _ = upload_to_gsheets(mega_tag_votes_table_formatted,
+                          'Tag Activity Dashboard', 'All Activity',
+                          format_columns=True)
 
 
-    tags_enriched = create_tags_table(tag_votes, tags, tag_rels, posts, mongo_db)
-    tags_table_formatted = format_tags_table_for_upload(tags_enriched)
 
-    return tags_table_formatted
 
 
 

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import etlw as et
-from utils import htmlBody2plaintext
+from utils import timed, htmlBody2plaintext
 from cellularautomaton import upload_to_gsheets
 
 
@@ -221,7 +221,7 @@ def format_mega_votes_table(table):
 
     return table[cols].sort_values(['votedAt'], ascending=[False])
 
-
+@timed
 def run_tag_pipeline(dfs, upload=True):
     votes = dfs['votes']
     posts = dfs['posts']

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import etlw as et
-from utils import timed, htmlBody2plaintext
+from utils import timed, htmlBody2plaintext, get_collection, get_mongo_db_object
 from cellularautomaton import upload_to_gsheets
 
 
@@ -244,9 +244,13 @@ def run_tag_pipeline(dfs, upload=True):
     mega_tag_votes_table = get_mega_tag_votes_table(tags, tag_rels, tag_votes, posts, users)
     mega_tag_votes_table_formatted = format_mega_votes_table(mega_tag_votes_table)
     mega_tag_votes_table_formatted['birth'] = pd.datetime.now()
-    _ = upload_to_gsheets(mega_tag_votes_table_formatted,
-                          'Tag Activity Dashboard', 'All Activity',
-                          format_columns=True)
+    _ = upload_to_gsheets(mega_tag_votes_table_formatted, 'Tag Activity Dashboard', 'All Activity', format_columns=True)
+
+    mega_tag_votes_table_formatted['date'] = mega_tag_votes_table_formatted['votedAt'].dt.date
+    _ = upload_to_gsheets(mega_tag_votes_table_formatted
+                          .sort_values(['date', 'is_core_tag', 'tag_name', 'post_title', 'votedAt'],
+                                       ascending=[False, False, True, True, False])
+                          , 'Tag Activity Dashboard', 'All Activity (Daily)', create_sheet=True, format_columns=True)
 
 
 

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -1,0 +1,101 @@
+from utils import htmlBody2plaintext
+import etlw as et
+
+
+
+def format_tags_posts_list(posts):
+    return ' '.join(['({number}) {title};  '.format(number=post.Index + 1, title=post.title)
+                     for post in posts.reset_index().itertuples()])
+
+
+def create_tag_posts_list(tag_rels, posts):
+    return (tag_rels
+            .merge(posts[['_id', 'title']], left_on='postId', right_on='_id')
+            .groupby('tagId')
+            .apply(format_tags_posts_list)
+            .to_frame('posts')
+            )
+
+
+def create_tags_table(votes, tags, tag_rels, posts, mongo_db_object):
+    """Main creation of tags table happens here"""
+
+    earliest_vote_on_tag = (votes
+                            .merge(tag_rels, left_on='documentId', right_on='_id')
+                            .groupby('tagId')['votedAt'].min()
+                            .to_frame('earliest_vote_on_tag')
+                            )
+
+    latest_post_added = (votes
+                         .merge(tag_rels[tag_rels['voteCount'] == 1], left_on='documentId', right_on='_id')
+                         .groupby(['tagId'])['votedAt'].max()
+                         .to_frame('latest_post_added')
+                         )
+
+    tag_posts_list = create_tag_posts_list(tag_rels, posts)
+
+    tags_enriched = (tags
+                     .merge(earliest_vote_on_tag, left_on='_id', right_index=True, how='left')
+                     .merge(latest_post_added, left_on='_id', right_index=True, how='left')
+                     .merge(tag_posts_list, left_on='_id', right_index=True, how='left')
+                     )
+
+    tags_enriched['description'] = htmlBody2plaintext(tags_enriched['description'].str['html'])
+    tags_enriched['description_last_edited'] = tags_enriched['description'].str['editedAt']
+
+    tag_index_body = list(mongo_db_object['posts'].find({'_id': 'DHJBEsi4XJDw2fRFq'}))[0]['contents']['html']
+    tags_enriched['in_tag_index'] = tags_enriched['slug'].apply(lambda x: ('lesswrong.com/tag/' + x) in tag_index_body)
+
+    return tags_enriched
+
+
+def format_tags_table_for_upload(tags_table):
+    tags_table['name'] = '=HYPERLINK("www.lesswrong.com/tag/'.lower() + tags_table['slug'] + '", "' + tags_table[
+        'name'] + '")'
+    tags_table['postCount'] = tags_table['postCount'].fillna(0)
+
+    cols = ['earliest_vote_on_tag',
+            'latest_post_added',
+            'name',
+            'postCount',
+            'in_tag_index',
+            'description',
+            'posts',
+            'description_last_edited',
+            'deleted',
+            ]
+
+    output = tags_table[cols].copy()
+    output = output.sort_values(['deleted', 'in_tag_index', 'latest_post_added'],
+                                ascending=[True, True, False])
+    output = output.rename({
+        'name': 'Tag Name',
+        'postCount': 'Post Count',
+    }, axis=1
+    )
+
+    return output
+
+
+
+
+
+def run_tag_pipeline(dfs):
+    mongo_db = et.get_mongo_db_object()
+
+    tags = et.get_collection('tags', mongo_db)
+    tag_rels = et.get_collection('tagrels', mongo_db)
+
+    votes = dfs['votes']
+    tag_votes = votes[votes['collectionName']=='TagRels']
+    posts = dfs['posts']
+
+
+    tags_enriched = create_tags_table(tag_votes, tags, tag_rels, posts, mongo_db)
+    tags_table_formatted = format_tags_table_for_upload(tags_enriched)
+
+    return tags_table_formatted
+
+
+
+

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -232,7 +232,7 @@ def run_tag_pipeline(dfs, upload=True):
     tags = et.get_collection('tags', mongo_db)
     tag_rels = et.get_collection('tagrels', mongo_db)
 
-    tag_votes = votes[votes['collectionName'] == 'TagRels']
+    tag_votes = votes[votes['collectionName']=='TagRels']
 
     tags_table = create_tags_table(tag_votes, tags.copy(), tag_rels, posts, mongo_db)
     tags_table_formatted = format_tags_table_for_upload(tags_table)

--- a/nobacksies.py
+++ b/nobacksies.py
@@ -1,6 +1,5 @@
 import pandas as pd
-import etlw as et
-from utils import timed, htmlBody2plaintext
+from utils import timed, htmlBody2plaintext, get_collection, get_mongo_db_object
 from cellularautomaton import upload_to_gsheets
 
 
@@ -227,10 +226,10 @@ def run_tag_pipeline(dfs, upload=True):
     posts = dfs['posts']
     users = dfs['users']
 
-    mongo_db = et.get_mongo_db_object()
+    mongo_db = get_mongo_db_object()
 
-    tags = et.get_collection('tags', mongo_db)
-    tag_rels = et.get_collection('tagrels', mongo_db)
+    tags = get_collection('tags', mongo_db)
+    tag_rels = get_collection('tagrels', mongo_db)
 
     tag_votes = votes[votes['collectionName']=='TagRels']
 
@@ -244,9 +243,13 @@ def run_tag_pipeline(dfs, upload=True):
     mega_tag_votes_table = get_mega_tag_votes_table(tags, tag_rels, tag_votes, posts, users)
     mega_tag_votes_table_formatted = format_mega_votes_table(mega_tag_votes_table)
     mega_tag_votes_table_formatted['birth'] = pd.datetime.now()
-    _ = upload_to_gsheets(mega_tag_votes_table_formatted,
-                          'Tag Activity Dashboard', 'All Activity',
-                          format_columns=True)
+    _ = upload_to_gsheets(mega_tag_votes_table_formatted, 'Tag Activity Dashboard', 'All Activity', format_columns=True)
+
+    mega_tag_votes_table_formatted['date'] = mega_tag_votes_table_formatted['votedAt'].dt.date
+    _ = upload_to_gsheets(mega_tag_votes_table_formatted
+                          .sort_values(['date', 'is_core_tag', 'tag_name', 'post_title', 'votedAt'],
+                                       ascending=[False, False, True, True, False])
+                          , 'Tag Activity Dashboard', 'All Activity (Daily)', create_sheet=True, format_columns=True)
 
 
 


### PR DESCRIPTION
This PR adds a step the pipeline that produces spreadsheets with the tagging info.
- Two tables: 1 at tags level, 1 at votes level (plus info at tag-rel level)

PR also includes fix for excluding tag votes from karmametric calculation.