### PR TITLE
remove_bad_upload_of_ga_metrics

### DIFF
--- a/google_analytics_ops.py
+++ b/google_analytics_ops.py
@@ -216,6 +216,6 @@ def run_ga_pipeline():
                                                  ga_metrics_gsheets['pages']['ga:pagePath'] + '", "' + \
                                                  ga_metrics_gsheets['pages']['ga:pagePath'] + '")'
 
-    [ga_gsheets_upload(df, name) for name, df in ga_metrics.items()]
+    # [ga_gsheets_upload(df, name) for name, df in ga_metrics.items()]
 
 


### PR DESCRIPTION
Upload was failing but we never use that sheet anyhow, so just disabling it for now. I know, bad practice to just comment out...