### PR TITLE
Post metrics 2 lw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Analytics
+
+## Database
+
+We use [dbmate](https://github.com/amacneil/dbmate) to migrate the database
+schema. See the migrations in /db/migrations/. It stores the current schema in
+/db/schema.sql.
+
+The raw table is one giant document store. To make it more query-friendly, we create views for each event type we need, such as `event_navigate`.

--- a/db/migrations/20210917095409_post_metrics_2.sql
+++ b/db/migrations/20210917095409_post_metrics_2.sql
@@ -1,0 +1,128 @@
+-- migrate:up
+
+-- Before this we needed to run:
+-- forumanalytics=> update raw set event = (event#>>'{}')::jsonb;
+-- which casts the older text strings to actual JSONB
+
+DROP INDEX IF EXISTS raw_event_type_post_id;
+
+CREATE or replace FUNCTION get_post_id_from_path(path TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  post_id TEXT;
+BEGIN
+  -- /posts/4fPxQjq6GFZgurSsf/room-for-other-things-how-to-adjust-if-ea-seems-overwhelming
+  -- /s/asdf/p/qwer
+  post_id := (SELECT (regexp_matches(path, '^(https?://[^/]*?)?/posts/([a-zA-Z0-9]+)/'))[2]);
+  if (post_id IS NOT NULL) THEN
+    RETURN post_id;
+  END IF;
+  post_id := (SELECT (regexp_matches(path, '^(https?://[^/]*?)?/s/[a-zA-Z0-9]+/p/([a-zA-Z0-9]+)'))[2]);
+  RETURN post_id;
+END
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE INDEX IF NOT EXISTS raw_event_type_post_id_timer_event ON raw (get_post_id_from_path(event->>'path')) WHERE event_type = 'timerEvent';
+CREATE INDEX IF NOT EXISTS raw_event_type_post_id_page_load_finished ON raw (get_post_id_from_path(event->>'url')) WHERE event_type = 'pageLoadFinished';
+CREATE INDEX IF NOT EXISTS raw_event_type_post_id_navigate ON raw (get_post_id_from_path(event->>'to')) WHERE event_type = 'navigate';
+
+-- Our old view restricts to timer events on posts, we're now just wanting to
+-- do all timer events
+DROP VIEW post_timer_event;
+
+CREATE VIEW event_timer_event AS (
+  SELECT
+    environment,
+    -- event_type is always 'timerEvent'
+    timestamp,
+    event->>'path' AS path,
+    event->>'tabId' AS tab_id,
+    event->>'userId' AS user_id,
+    (event->>'seconds')::INTEGER AS seconds,
+    event->>'clientId' AS client_id,
+    (event->>'increment')::INTEGER AS increment,
+    get_post_id_from_path(event->>'path') AS post_id
+  FROM raw
+  WHERE event_type = 'timerEvent'
+);
+
+-- TODO: these paths aren't necessarily correct and need to be updated for
+-- whatever a pageLoadFinished event normally has
+CREATE VIEW event_page_load_finished AS (
+  SELECT
+    environment,
+    -- event_type is always 'timerEvent'
+    timestamp,
+    event->>'path' AS path,
+    event->>'tabId' AS tab_id,
+    event->>'userId' AS user_id,
+    (event->>'seconds')::INTEGER AS seconds,
+    event->>'clientId' AS client_id,
+    (event->>'increment')::INTEGER AS increment,
+    get_post_id_from_path(event->>'url') AS post_id
+  FROM raw
+  WHERE event_type = 'pageLoadFinished'
+);
+
+CREATE VIEW event_navigate AS (
+  SELECT
+    environment,
+    -- event_type is always 'timerEvent'
+    timestamp,
+    event->>'tabId' AS tab_id,
+    event->>'userId' AS user_id,
+    event->>'clientId' AS client_id,
+    event->>'from' AS from,
+    event->>'to' AS to,
+    get_post_id_from_path(event->>'to') AS to_post_id,
+    get_post_id_from_path(event->>'from') AS from_post_id
+  FROM raw
+  WHERE event_type = 'navigate'
+);
+
+--------------------------------------------------------------------------------
+-- migrate:down
+
+-- DROP INDEX raw_event_type_post_id_timer_event;
+-- DROP INDEX raw_event_type_post_id_page_load_finished;
+-- DROP INDEX raw_event_type_post_id_navigate;
+
+
+CREATE or replace FUNCTION get_post_id_from_path(path TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  post_id TEXT;
+BEGIN
+  -- /posts/4fPxQjq6GFZgurSsf/room-for-other-things-how-to-adjust-if-ea-seems-overwhelming
+  -- /s/asdf/p/qwer
+  post_id := (SELECT (regexp_matches(path, '^/posts/([a-zA-Z0-9]+)/'))[1]);
+  if (post_id IS NOT NULL) THEN
+    RETURN post_id;
+  END IF;
+  post_id := (SELECT (regexp_matches(path, '^/s/[a-zA-Z0-9]+/p/([a-zA-Z0-9]+)'))[1]);
+  RETURN post_id;
+END
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+-- CREATE INDEX raw_event_type_post_id ON raw (event_type, get_post_id_from_path(event->>'path'));
+
+DROP VIEW event_timer_event;
+DROP VIEW event_page_load_finished;
+DROP VIEW event_navigate;
+
+CREATE VIEW post_timer_event AS (
+  SELECT
+    environment,
+    -- event_type is always 'timerEvent'
+    timestamp,
+    event->>'path' AS path,
+    event->>'tabId' AS tabId,
+    event->>'userId' AS userId,
+    (event->>'seconds')::INTEGER AS seconds,
+    event->>'clientId' AS clientId,
+    (event->>'increment')::INTEGER AS increment,
+    get_post_id_from_path(event->>'path') AS post_id
+  FROM raw
+  WHERE event_type = 'timerEvent'
+    AND get_post_id_from_path(event->>'path') IS NOT NULL
+);

--- a/db/migrations/20210917095409_post_metrics_2.sql
+++ b/db/migrations/20210917095409_post_metrics_2.sql
@@ -1,4 +1,6 @@
+-- #############################################################################
 -- migrate:up
+-- #############################################################################
 
 -- Before this we needed to run:
 -- forumanalytics=> update raw set event = (event#>>'{}')::jsonb;
@@ -51,15 +53,69 @@ CREATE VIEW event_timer_event AS (
 CREATE VIEW event_page_load_finished AS (
   SELECT
     environment,
-    -- event_type is always 'timerEvent'
+    -- event_type is always 'pageLoadFinished'
     timestamp,
-    event->>'path' AS path,
+    event->>'url' AS url,
     event->>'tabId' AS tab_id,
     event->>'userId' AS user_id,
-    (event->>'seconds')::INTEGER AS seconds,
     event->>'clientId' AS client_id,
-    (event->>'increment')::INTEGER AS increment,
-    get_post_id_from_path(event->>'url') AS post_id
+    event->>'referrer' AS referrer,
+    get_post_id_from_path(event->>'url') AS post_id,
+    (event->>'performance')::JSONB->>'memory' AS performance_memory,
+    -- https://stackoverflow.com/questions/16808486/explanation-of-window-performance-javascript
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'navigationStart'
+      AS performance_timing_navigation_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'redirectStart'
+      AS performance_timing_redirect_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'redirectEnd'
+      AS performance_timing_redirect_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'fetchStart'
+      AS performance_timing_fetch_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domainLookupStart'
+      AS performance_timing_domain_lookup_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domainLookupEnd'
+      AS performance_timing_domain_lookup_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'connectStart'
+      AS performance_timing_connect_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'secureConnectionStart'
+      AS performance_timing_secure_connection_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'connectEnd'
+      AS performance_timing_connect_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'requestStart'
+      AS performance_timing_request_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'responseStart'
+      AS performance_timing_response_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'unloadEventStart'
+      AS performance_timing_unload_event_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'unloadEventEnd'
+      AS performance_timing_unload_event_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'responseEnd'
+      AS performance_timing_response_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domLoading'
+      AS performance_timing_dom_loading,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domInteractive'
+      AS performance_timing_dom_interactive,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domContentLoadedEventStart'
+      AS performance_timing_dom_content_loaded_event_start,
+    ((event->>'perormance')::JSONB->>'timing')::JSONB->>'domContentLoadedEventEnd'
+      AS performance_timing_dom_content_loaded_event_end,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'domComplete'
+      AS performance_timing_dom_complete,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'loadEventStart'
+      AS performance_timing_load_event_start,
+    ((event->>'performance')::JSONB->>'timing')::JSONB->>'loadEventEnd'
+      AS performance_timing_load_event_end,
+    (event->>'performance')::JSONB->>'timeOrigin' AS performance_time_origin,
+    (event->>'browserProps')::JSONB->>'userAgent' AS browser_props_user_agent,
+    -- The following come from 'bowser'
+    ((event->>'browserProps')::JSONB->>'mobile')::BOOLEAN AS browser_props_mobile,
+    ((event->>'browserProps')::JSONB->>'tablet')::BOOLEAN AS browser_props_tablet,
+    ((event->>'browserProps')::JSONB->>'chrome')::BOOLEAN AS browser_props_chrome,
+    ((event->>'browserProps')::JSONB->>'firefox')::BOOLEAN AS browser_props_firefox,
+    ((event->>'browserProps')::JSONB->>'safari')::BOOLEAN AS browser_props_safari,
+    (event->>'browserProps')::JSONB->>'osname' AS browser_props_osname,
+    ((event->>'browserProps')::JSONB->>'blocks')::JSONB->>'blocksGA' AS browser_props_blocks_ga,
+    ((event->>'browserProps')::JSONB->>'blocks')::JSONB->>'blocksGTM' AS browser_props_blocks_gtm
   FROM raw
   WHERE event_type = 'pageLoadFinished'
 );
@@ -67,7 +123,7 @@ CREATE VIEW event_page_load_finished AS (
 CREATE VIEW event_navigate AS (
   SELECT
     environment,
-    -- event_type is always 'timerEvent'
+    -- event_type is always 'navigate'
     timestamp,
     event->>'tabId' AS tab_id,
     event->>'userId' AS user_id,
@@ -80,8 +136,41 @@ CREATE VIEW event_navigate AS (
   WHERE event_type = 'navigate'
 );
 
---------------------------------------------------------------------------------
+CREATE VIEW page_view AS (
+  SELECT
+    environment,
+    event_type,
+    timestamp,
+    tab_id,
+    user_id,
+    client_id,
+    post_id
+  FROM (
+    SELECT
+      environment,
+      'page_load_finished' AS event_type,
+      timestamp,
+      tab_id,
+      user_id,
+      client_id,
+      post_id
+    FROM event_page_load_finished
+    UNION ALL
+    SELECT
+      environment,
+      'navigate' AS event_type,
+      timestamp,
+      tab_id,
+      user_id,
+      client_id,
+      to_post_id AS post_id
+    FROM event_navigate
+  ) a
+);
+
+-- #############################################################################
 -- migrate:down
+-- #############################################################################
 
 -- DROP INDEX raw_event_type_post_id_timer_event;
 -- DROP INDEX raw_event_type_post_id_page_load_finished;
@@ -105,6 +194,8 @@ END
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
 -- CREATE INDEX raw_event_type_post_id ON raw (event_type, get_post_id_from_path(event->>'path'));
+
+DROP VIEW page_view;
 
 DROP VIEW event_timer_event;
 DROP VIEW event_page_load_finished;

--- a/db/migrations/20210917095409_post_metrics_2.sql
+++ b/db/migrations/20210917095409_post_metrics_2.sql
@@ -1,10 +1,13 @@
+-- Make more views, some refactoring to deal with the different ways events can
+-- store the path
+
 -- #############################################################################
 -- migrate:up
 -- #############################################################################
 
 DROP INDEX IF EXISTS raw_event_type_post_id;
 
-CREATE or replace FUNCTION get_post_id_from_path(path TEXT)
+CREATE OR REPLACE FUNCTION get_post_id_from_path(path TEXT)
 RETURNS TEXT AS $$
 DECLARE
   post_id TEXT;
@@ -44,8 +47,6 @@ CREATE VIEW event_timer_event AS (
   WHERE event_type = 'timerEvent'
 );
 
--- TODO: these paths aren't necessarily correct and need to be updated for
--- whatever a pageLoadFinished event normally has
 CREATE VIEW event_page_load_finished AS (
   SELECT
     environment,
@@ -172,7 +173,7 @@ DROP INDEX raw_event_type_post_id_timer_event;
 DROP INDEX raw_event_type_post_id_page_load_finished;
 DROP INDEX raw_event_type_post_id_navigate;
 
-CREATE or replace FUNCTION get_post_id_from_path(path TEXT)
+CREATE OR REPLACE FUNCTION get_post_id_from_path(path TEXT)
 RETURNS TEXT AS $$
 DECLARE
   post_id TEXT;

--- a/db/migrations/20210917095409_post_metrics_2.sql
+++ b/db/migrations/20210917095409_post_metrics_2.sql
@@ -168,10 +168,9 @@ CREATE VIEW page_view AS (
 -- migrate:down
 -- #############################################################################
 
--- DROP INDEX raw_event_type_post_id_timer_event;
--- DROP INDEX raw_event_type_post_id_page_load_finished;
--- DROP INDEX raw_event_type_post_id_navigate;
-
+DROP INDEX raw_event_type_post_id_timer_event;
+DROP INDEX raw_event_type_post_id_page_load_finished;
+DROP INDEX raw_event_type_post_id_navigate;
 
 CREATE or replace FUNCTION get_post_id_from_path(path TEXT)
 RETURNS TEXT AS $$
@@ -189,7 +188,7 @@ BEGIN
 END
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
--- CREATE INDEX raw_event_type_post_id ON raw (event_type, get_post_id_from_path(event->>'path'));
+CREATE INDEX raw_event_type_post_id ON raw (event_type, get_post_id_from_path(event->>'path'));
 
 DROP VIEW page_view;
 

--- a/db/migrations/20210917095409_post_metrics_2.sql
+++ b/db/migrations/20210917095409_post_metrics_2.sql
@@ -2,10 +2,6 @@
 -- migrate:up
 -- #############################################################################
 
--- Before this we needed to run:
--- forumanalytics=> update raw set event = (event#>>'{}')::jsonb;
--- which casts the older text strings to actual JSONB
-
 DROP INDEX IF EXISTS raw_event_type_post_id;
 
 CREATE or replace FUNCTION get_post_id_from_path(path TEXT)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,130 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: pgtap; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgtap; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pgtap IS 'Unit testing for PostgreSQL';
+
+
+--
+-- Name: get_post_id_from_path(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_post_id_from_path(path text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE STRICT
+    AS $$
+DECLARE
+  post_id TEXT;
+BEGIN
+  -- /posts/4fPxQjq6GFZgurSsf/room-for-other-things-how-to-adjust-if-ea-seems-overwhelming
+  -- /s/asdf/p/qwer
+  post_id := (SELECT (regexp_matches(path, '^/posts/([a-zA-Z0-9]+)/'))[1]);
+  if (post_id IS NOT NULL) THEN
+    RETURN post_id;
+  END IF;
+  post_id := (SELECT (regexp_matches(path, '^/s/[a-zA-Z0-9]+/p/([a-zA-Z0-9]+)'))[1]);
+  RETURN post_id;
+END
+$$;
+
+
+SET default_tablespace = '';
+
+--
+-- Name: raw; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.raw (
+    environment text,
+    event_type text,
+    "timestamp" timestamp without time zone,
+    event jsonb
+);
+
+
+--
+-- Name: post_timer_event; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.post_timer_event AS
+ SELECT raw.environment,
+    raw."timestamp",
+    (raw.event ->> 'path'::text) AS path,
+    (raw.event ->> 'tabId'::text) AS tabid,
+    (raw.event ->> 'userId'::text) AS userid,
+    ((raw.event ->> 'seconds'::text))::integer AS seconds,
+    (raw.event ->> 'clientId'::text) AS clientid,
+    ((raw.event ->> 'increment'::text))::integer AS increment,
+    public.get_post_id_from_path((raw.event ->> 'path'::text)) AS post_id
+   FROM public.raw
+  WHERE ((raw.event_type = 'timerEvent'::text) AND (public.get_post_id_from_path((raw.event ->> 'path'::text)) IS NOT NULL));
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying(255) NOT NULL
+);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: raw_event_type_timestamp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_event_type_timestamp_idx ON public.raw USING btree (event_type, "timestamp");
+
+
+--
+-- Name: raw_timestamp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_timestamp_idx ON public.raw USING btree ("timestamp");
+
+
+--
+-- Name: raw_timestamp_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_timestamp_idx1 ON public.raw USING btree ("timestamp");
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+
+--
+-- Dbmate schema migrations
+--
+
+INSERT INTO public.schema_migrations (version) VALUES
+    ('20210824104514'),
+    ('20210824110654'),
+    ('20210824111234');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -35,17 +35,19 @@ DECLARE
 BEGIN
   -- /posts/4fPxQjq6GFZgurSsf/room-for-other-things-how-to-adjust-if-ea-seems-overwhelming
   -- /s/asdf/p/qwer
-  post_id := (SELECT (regexp_matches(path, '^/posts/([a-zA-Z0-9]+)/'))[1]);
+  post_id := (SELECT (regexp_matches(path, '^(https?://[^/]*?)?/posts/([a-zA-Z0-9]+)/'))[2]);
   if (post_id IS NOT NULL) THEN
     RETURN post_id;
   END IF;
-  post_id := (SELECT (regexp_matches(path, '^/s/[a-zA-Z0-9]+/p/([a-zA-Z0-9]+)'))[1]);
+  post_id := (SELECT (regexp_matches(path, '^(https?://[^/]*?)?/s/[a-zA-Z0-9]+/p/([a-zA-Z0-9]+)'))[2]);
   RETURN post_id;
 END
 $$;
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: raw; Type: TABLE; Schema: public; Owner: -
@@ -60,21 +62,119 @@ CREATE TABLE public.raw (
 
 
 --
--- Name: post_timer_event; Type: VIEW; Schema: public; Owner: -
+-- Name: event_navigate; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.post_timer_event AS
+CREATE VIEW public.event_navigate AS
+ SELECT raw.environment,
+    raw."timestamp",
+    (raw.event ->> 'tabId'::text) AS tab_id,
+    (raw.event ->> 'userId'::text) AS user_id,
+    (raw.event ->> 'clientId'::text) AS client_id,
+    (raw.event ->> 'from'::text) AS "from",
+    (raw.event ->> 'to'::text) AS "to",
+    public.get_post_id_from_path((raw.event ->> 'to'::text)) AS to_post_id,
+    public.get_post_id_from_path((raw.event ->> 'from'::text)) AS from_post_id
+   FROM public.raw
+  WHERE (raw.event_type = 'navigate'::text);
+
+
+--
+-- Name: event_page_load_finished; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.event_page_load_finished AS
+ SELECT raw.environment,
+    raw."timestamp",
+    (raw.event ->> 'url'::text) AS url,
+    (raw.event ->> 'tabId'::text) AS tab_id,
+    (raw.event ->> 'userId'::text) AS user_id,
+    (raw.event ->> 'clientId'::text) AS client_id,
+    (raw.event ->> 'referrer'::text) AS referrer,
+    public.get_post_id_from_path((raw.event ->> 'url'::text)) AS post_id,
+    (((raw.event ->> 'performance'::text))::jsonb ->> 'memory'::text) AS performance_memory,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'navigationStart'::text) AS performance_timing_navigation_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'redirectStart'::text) AS performance_timing_redirect_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'redirectEnd'::text) AS performance_timing_redirect_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'fetchStart'::text) AS performance_timing_fetch_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domainLookupStart'::text) AS performance_timing_domain_lookup_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domainLookupEnd'::text) AS performance_timing_domain_lookup_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'connectStart'::text) AS performance_timing_connect_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'secureConnectionStart'::text) AS performance_timing_secure_connection_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'connectEnd'::text) AS performance_timing_connect_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'requestStart'::text) AS performance_timing_request_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'responseStart'::text) AS performance_timing_response_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'unloadEventStart'::text) AS performance_timing_unload_event_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'unloadEventEnd'::text) AS performance_timing_unload_event_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'responseEnd'::text) AS performance_timing_response_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domLoading'::text) AS performance_timing_dom_loading,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domInteractive'::text) AS performance_timing_dom_interactive,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domContentLoadedEventStart'::text) AS performance_timing_dom_content_loaded_event_start,
+    (((((raw.event ->> 'perormance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domContentLoadedEventEnd'::text) AS performance_timing_dom_content_loaded_event_end,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'domComplete'::text) AS performance_timing_dom_complete,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'loadEventStart'::text) AS performance_timing_load_event_start,
+    (((((raw.event ->> 'performance'::text))::jsonb ->> 'timing'::text))::jsonb ->> 'loadEventEnd'::text) AS performance_timing_load_event_end,
+    (((raw.event ->> 'performance'::text))::jsonb ->> 'timeOrigin'::text) AS performance_time_origin,
+    (((raw.event ->> 'browserProps'::text))::jsonb ->> 'userAgent'::text) AS browser_props_user_agent,
+    ((((raw.event ->> 'browserProps'::text))::jsonb ->> 'mobile'::text))::boolean AS browser_props_mobile,
+    ((((raw.event ->> 'browserProps'::text))::jsonb ->> 'tablet'::text))::boolean AS browser_props_tablet,
+    ((((raw.event ->> 'browserProps'::text))::jsonb ->> 'chrome'::text))::boolean AS browser_props_chrome,
+    ((((raw.event ->> 'browserProps'::text))::jsonb ->> 'firefox'::text))::boolean AS browser_props_firefox,
+    ((((raw.event ->> 'browserProps'::text))::jsonb ->> 'safari'::text))::boolean AS browser_props_safari,
+    (((raw.event ->> 'browserProps'::text))::jsonb ->> 'osname'::text) AS browser_props_osname,
+    (((((raw.event ->> 'browserProps'::text))::jsonb ->> 'blocks'::text))::jsonb ->> 'blocksGA'::text) AS browser_props_blocks_ga,
+    (((((raw.event ->> 'browserProps'::text))::jsonb ->> 'blocks'::text))::jsonb ->> 'blocksGTM'::text) AS browser_props_blocks_gtm
+   FROM public.raw
+  WHERE (raw.event_type = 'pageLoadFinished'::text);
+
+
+--
+-- Name: event_timer_event; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.event_timer_event AS
  SELECT raw.environment,
     raw."timestamp",
     (raw.event ->> 'path'::text) AS path,
-    (raw.event ->> 'tabId'::text) AS tabid,
-    (raw.event ->> 'userId'::text) AS userid,
+    (raw.event ->> 'tabId'::text) AS tab_id,
+    (raw.event ->> 'userId'::text) AS user_id,
     ((raw.event ->> 'seconds'::text))::integer AS seconds,
-    (raw.event ->> 'clientId'::text) AS clientid,
+    (raw.event ->> 'clientId'::text) AS client_id,
     ((raw.event ->> 'increment'::text))::integer AS increment,
     public.get_post_id_from_path((raw.event ->> 'path'::text)) AS post_id
    FROM public.raw
-  WHERE ((raw.event_type = 'timerEvent'::text) AND (public.get_post_id_from_path((raw.event ->> 'path'::text)) IS NOT NULL));
+  WHERE (raw.event_type = 'timerEvent'::text);
+
+
+--
+-- Name: page_view; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.page_view AS
+ SELECT a.environment,
+    a.event_type,
+    a."timestamp",
+    a.tab_id,
+    a.user_id,
+    a.client_id,
+    a.post_id
+   FROM ( SELECT event_page_load_finished.environment,
+            'page_load_finished'::text AS event_type,
+            event_page_load_finished."timestamp",
+            event_page_load_finished.tab_id,
+            event_page_load_finished.user_id,
+            event_page_load_finished.client_id,
+            event_page_load_finished.post_id
+           FROM public.event_page_load_finished
+        UNION ALL
+         SELECT event_navigate.environment,
+            'navigate'::text AS event_type,
+            event_navigate."timestamp",
+            event_navigate.tab_id,
+            event_navigate.user_id,
+            event_navigate.client_id,
+            event_navigate.to_post_id AS post_id
+           FROM public.event_navigate) a;
 
 
 --
@@ -92,6 +192,27 @@ CREATE TABLE public.schema_migrations (
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: raw_event_type_post_id_navigate; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_event_type_post_id_navigate ON public.raw USING btree (public.get_post_id_from_path((event ->> 'to'::text))) WHERE (event_type = 'navigate'::text);
+
+
+--
+-- Name: raw_event_type_post_id_page_load_finished; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_event_type_post_id_page_load_finished ON public.raw USING btree (public.get_post_id_from_path((event ->> 'url'::text))) WHERE (event_type = 'pageLoadFinished'::text);
+
+
+--
+-- Name: raw_event_type_post_id_timer_event; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX raw_event_type_post_id_timer_event ON public.raw USING btree (public.get_post_id_from_path((event ->> 'path'::text))) WHERE (event_type = 'timerEvent'::text);
 
 
 --
@@ -127,4 +248,5 @@ CREATE INDEX raw_timestamp_idx1 ON public.raw USING btree ("timestamp");
 INSERT INTO public.schema_migrations (version) VALUES
     ('20210824104514'),
     ('20210824110654'),
-    ('20210824111234');
+    ('20210824111234'),
+    ('20210917095409');

--- a/db/tests/author_metrics_tests.sql
+++ b/db/tests/author_metrics_tests.sql
@@ -1,45 +1,48 @@
 BEGIN;
 
-TRUNCATE TABLE raw;
+SELECT plan(7);
 
-CREATE TABLE get_post_id_from_path_test (
-  path text,
-  expected_post_id TEXT,
-  description TEXT
-);
-
-INSERT INTO get_post_id_from_path_test VALUES (
-  '/',
+SELECT is(
+  get_post_id_from_path('/'),
   NULL,
-  'Nothing there'
-), (
-  '/posts/7irLXuSJGW7CjfunB/new-start-here',
-  '7irLXuSJGW7CjfunB',
-  'Simple post'
-), (
-  '/s/6gFGprxo27o7desCs/p/yBHqxKYS5rZot3gdq',
-  'yBHqxKYS5rZot3gdq',
-  'Post viewed in sequence view'
+  'returns null if no post id in string'
 );
 
-CREATE FUNCTION test_get_post_id_from_path ()
-RETURNS SETOF TEXT AS $$
-DECLARE
-  test get_post_id_from_path_test;
-BEGIN
-  FOR test IN (SELECT * FROM get_post_id_from_path_test) LOOP
-    RETURN NEXT is(
-      get_post_id_from_path(test.path),
-      test.expected_post_id,
-      test.description
-    );
-  END LOOP;
-END
-$$ LANGUAGE plpgsql;
+SELECT is(
+  get_post_id_from_path('/posts/7irLXuSJGW7CjfunB/new-start-here'),
+  '7irLXuSJGW7CjfunB',
+  'returns post id from relative path'
+);
 
-SELECT plan(3);
+SELECT is(
+  get_post_id_from_path('/s/6gFGprxo27o7desCs/p/yBHqxKYS5rZot3gdq'),
+  'yBHqxKYS5rZot3gdq',
+  'returns post id from relative path in sequence view'
+);
 
-SELECT test_get_post_id_from_path();
+SELECT is(
+  get_post_id_from_path('http://localhost:3000/posts/7irLXuSJGW7CjfunB/new-start-here'),
+  '7irLXuSJGW7CjfunB',
+  'returns post id from absolute path (http)'
+);
+
+SELECT is(
+  get_post_id_from_path('http://localhost:3000/s/6gFGprxo27o7desCs/p/yBHqxKYS5rZot3gdq'),
+  'yBHqxKYS5rZot3gdq',
+  'returns post id from absolute path in sequence view (http)'
+);
+
+SELECT is(
+  get_post_id_from_path('https://forum.effectivealtruism.org/posts/7irLXuSJGW7CjfunB/new-start-here'),
+  '7irLXuSJGW7CjfunB',
+  'returns post id from absolute path (https)'
+);
+
+SELECT is(
+  get_post_id_from_path('https://forum.effectivealtruism.org/s/6gFGprxo27o7desCs/p/yBHqxKYS5rZot3gdq'),
+  'yBHqxKYS5rZot3gdq',
+  'returns post id from absolute path in sequence view (https)'
+);
 
 SELECT finish();
 


### PR DESCRIPTION
Already reviewed, see: https://github.com/centre-for-effective-altruism/ForumAnalytics/pull/11

---

Companion PR to: https://github.com/LessWrong2/Lesswrong2/pull/4208

Creates some convenience views for a better querying experience. As it turns out that different eventTypes store their path information in different places, I had to update the post_id index to be a conditional index.

I also added schema.sql, which I mistakenly hadn't included before.

